### PR TITLE
Expand extraction support for remote archive files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ cache:
     - $HOME/.bazelenv
     - $HOME/Library/Caches/Bazel
     - $HOME/.bazel_pod_store
-osx_image: xcode10
+osx_image: xcode10.2
 script: make ci

--- a/BazelExtensions/workspace.bzl
+++ b/BazelExtensions/workspace.bzl
@@ -41,7 +41,9 @@ def _fetch_remote_repo(repository_ctx, repo_tool_bin, target_name, url):
         "--sub_dir",
         repository_ctx.attr.strip_prefix,
         "--trace",
-        "true" if repository_ctx.attr.trace else "false"
+        "true" if repository_ctx.attr.trace else "false",
+        "--handler",
+        repository_ctx.attr.extraction_handler
     ]
 
     fetch_output = _exec(repository_ctx, fetch_cmd)
@@ -180,6 +182,8 @@ pod_repo_ = repository_rule(
         "enable_modules": attr.bool(default=True, mandatory=True),
         "generate_module_map": attr.bool(default=True, mandatory=True),
         "header_visibility": attr.string(),
+        "extraction_handler": attr.string(values=["zip", "tar", "default"],
+                                          default="default"),
     }
 )
 
@@ -198,6 +202,7 @@ def new_pod_repository(name,
                        enable_modules=True,
                        generate_module_map=None,
                        header_visibility="pod_support",
+                       extraction_handler="default",
                        ):
     """Declare a repository for a Pod
     Args:
@@ -258,6 +263,10 @@ def new_pod_repository(name,
 
          header_visibility: DEPRECATED: This is replaced by headermaps:
          https://github.com/bazelbuild/bazel/pull/3712
+
+         extraction_handler: override for how the target file from `url` is
+         extracted as, can be either `tar` or `zip`.  The default is `default`
+         which will try and infer from the file extension of the target file.
     """
     if generate_module_map == None:
         generate_module_map = enable_modules
@@ -279,5 +288,6 @@ def new_pod_repository(name,
         trace=trace,
         enable_modules=enable_modules,
         generate_module_map=generate_module_map,
-        header_visibility=header_visibility
+        header_visibility=header_visibility,
+        extraction_handler=extraction_handler
     )

--- a/Examples/BasiciOS/WORKSPACE
+++ b/Examples/BasiciOS/WORKSPACE
@@ -16,7 +16,7 @@ git_repository(
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.6.0",
+    tag = "0.16.1",
 )
 
 load(
@@ -26,18 +26,19 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
 
 load("@rules_pods//BazelExtensions:workspace.bzl", "new_pod_repository")
 

--- a/Examples/Example.Makefile
+++ b/Examples/Example.Makefile
@@ -6,12 +6,12 @@ BAZEL_WRAPPER=$(RULES_PODS_DIR)/tools/bazelwrapper
 
 # Workaround for symlink weirdness.
 # Currently `bazelwrapper` relies on pwd, which causes issues here
-BAZEL=~/.bazelenv/versions/0.18.0/bin/bazel
+BAZEL=~/.bazelenv/versions/0.25.2/bin/bazel
 
 # Override the repository to point at the source. It does a source build of the
 # current code.
 BAZEL_OPTS=--override_repository=rules_pods=$(RULES_PODS_DIR) \
-		--disk_cache=$(HOME)/Library/Caches/Bazel
+		--disk_cache=$(HOME)/Library/Caches/Bazel  --apple_platform_type=ios
 
 all: fetch build
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ compile_commands.json:
 
 
 
-TESTED_BAZEL_VERSION=0.18.0
+TESTED_BAZEL_VERSION=0.25.2
 
 # Make a binary archive of PodToBUILD with the official github cli `hub`
 github_release:

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
         "state": {
           "branch": null,
-          "revision": "e5871587ddf85c0bcf84f773925655f2f83ef336",
-          "version": "0.0.7"
+          "revision": "bd9cb30ceee1f21c02f51a7168f58471449807d8",
+          "version": "0.1.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/typelift/SwiftCheck.git",
         "state": {
           "branch": null,
-          "revision": "43ffe7ab48366c36a697c54bcdd257876edd6fc6",
-          "version": "0.10.0"
+          "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",
+          "version": "0.12.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In the root directory, add `rules_pods` to the Bazel `WORKSPACE`.
 ```
 http_archive(
     name = "rules_pods",
-    urls = ["https://github.com/pinterest/PodToBUILD/releases/download/0.22.0-ee8466e/PodToBUILD.zip"],
+    urls = ["https://github.com/pinterest/PodToBUILD/releases/download/0.25.2-fc71a0b/PodToBUILD.zip"],
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ there is no need to add an entry for them.
 
 `header_visibility`: DEPRECATED: This is replaced by headermaps: https://github.com/Bazelbuild/Bazel/pull/3712
 
+`extraction_handler`: explicitly define what filetype to treat the remote 
+target as.  Supports `tar` and `zip`.  If unset, will try and infer from the
+file extension.
+
 ### Known Complications
 
 ### Incompatible file paths

--- a/Sources/PodToBUILD/ShellContext.swift
+++ b/Sources/PodToBUILD/ShellContext.swift
@@ -271,11 +271,14 @@ public struct SystemShellContext : ShellContext {
     
     public func tmpdir() -> String {
         log("CREATE TMPDIR")
-        let result = NSTemporaryDirectory() as String
-        guard !result.isEmpty else {
+        // Taken from https://stackoverflow.com/a/46701313/3000133
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        } catch {
             fatalError("Can't create temp dir")
         }
-        return result
+        return url.path
     }
 
     // MARK: - Private

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -401,7 +401,7 @@ public enum RepoActions {
         // Extract the downloaded archive
         let extractDir = shell.tmpdir()
         func extract() -> CommandOutput {
-            var extractionHandler = fetchOptions.extractionHandler.isEmpty ? "default" : fetchOpts.extractionHandler;
+            var extractionHandler = fetchOptions.extractionHandler.isEmpty ? "default" : fetchOptions.extractionHandler;
             if extractionHandler == "default" {
                 let lowercasedFileName = fileName.lowercased()
                 if lowercasedFileName.hasSuffix("zip") {

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -500,7 +500,7 @@ public enum RepoActions {
         return "mkdir -p " + rootDir + " && " +
             "cd " + rootDir + " && " +
             "mkdir -p OUT && " +
-            "tar -xzvf " + fileName + " -C OUT > /dev/null && " +
+            "tar -xzvf " + fileName + " -C OUT > /dev/null 2>&1 && " +
             "rm -rf " + fileName
     }
 }

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -433,7 +433,8 @@ public enum RepoActions {
                     ),
                 ])
             } else {
-                fatalError("The extraction handler value is invalid: \(extractionHandler ?? 'default')")
+                let handler = extractionHandler ?? "default"
+                fatalError("The extraction handler value is invalid: \(handler)")
             }
         }
 

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -433,7 +433,7 @@ public enum RepoActions {
                     ),
                 ])
             } else {
-                fatalError("The extraction handler value is invalid: \(extractionHandler)")
+                fatalError("The extraction handler value is invalid: \(extractionHandler ?? 'default')")
             }
         }
 

--- a/Tests/BuildTests/BuildTest.swift
+++ b/Tests/BuildTests/BuildTest.swift
@@ -32,7 +32,12 @@ class BuildTests: XCTestCase {
             let fetchResult = fetchTask.launch()
             XCTAssertEqual(fetchResult.terminationStatus, 0)
             guard fetchResult.terminationStatus == 0 else {
-                fatalError("Can't setup test root")
+                fatalError(
+                        "Can't setup test root."
+                                + "\nCMD:\n\(fetchTask.debugDescription)"
+                                + "\nSTDOUT:\n\(fetchResult.standardOutputAsString)"
+                                + "\nSTDERR:\n\(fetchResult.standardErrorAsString)"
+                )
             }
             let bazelScript = "make -C \(rootDir)/Examples/\(example)"
             print("running bazel:", bazelScript)

--- a/Tests/PodToBUILDTests/PodStoreTests.swift
+++ b/Tests/PodToBUILDTests/PodStoreTests.swift
@@ -15,22 +15,23 @@ let testPodName = "Foo"
 let fetchOpts = FetchOptions(podName: testPodName,
                     url: "http://pinner.com/foo.zip",
                     trace: false,
-                    subDir: nil)
+                    subDir: nil,
+                    extractionHandler: "default")
 
 class PodStoreTests: XCTestCase {
 
     var downloads: String {
         return "%TMP%"
     }
-    
+
     var extractDir: String {
         return "%TMP%"
     }
-    
+
 	var downloadPath: String {
         return downloads + "/" + testPodName + "-" + "foo.zip"
-    }   
-        
+    }
+
     var hasDir: ShellInvocation {
         return MakeShellInvocation("/bin/[", arguments: ["-e", cacheRoot(forPod:
                 testPodName, url: "http://pinner.com/foo.zip"), "]"], exitCode: 1)
@@ -51,13 +52,13 @@ class PodStoreTests: XCTestCase {
             )
         )
     }
-    
+
     func testZipExtraction() {
         let hasDir =  MakeShellInvocation("/bin/[", arguments: ["-e",
                 cacheRoot(forPod: testPodName, url: "http://pinner.com/foo.zip"),
                 "]"], exitCode: 1)
 
-        
+
         let extract = MakeShellInvocation("/bin/sh",
                                           arguments: ["-c", RepoActions.unzipTransaction(
                                             rootDir: escape(extractDir),
@@ -81,7 +82,7 @@ class PodStoreTests: XCTestCase {
         let shell = LogicalShellContext(commandInvocations: [
             hasDir,
             ])
-        
+
         RepoActions.fetch(shell: shell, fetchOptions: fetchOpts)
         XCTAssertFalse(shell.executed(encodedCommand:
                 LogicalShellContext.encodeDownload(url: URL(string: fetchOpts.url)!, toFile: downloadPath)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.13.0",
+    tag = "0.16.1",
 )
 
 load(
@@ -13,15 +13,16 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.6.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -58,7 +58,8 @@ class RepositoryContext(object):
             enable_modules = True,
             generate_module_map = True,
             header_visibility = "pod_support",
-            src_root = None):
+            src_root = None,
+            extraction_handler = "default"):
         self.target_name = target_name
         self.url = url
         self.podspec_url = podspec_url
@@ -71,6 +72,7 @@ class RepositoryContext(object):
         self.generate_module_map = generate_module_map
         self.header_visibility = header_visibility
         self.src_root = src_root
+        self.extraction_handler = extraction_handler
 
     def GetPodRootDir(self):
         return self.src_root + "/Vendor/" + self.target_name
@@ -129,7 +131,9 @@ def _fetch_remote_repo(repository_ctx, repo_tool_bin, target_name, url):
         "--sub_dir",
         repository_ctx.strip_prefix,
         "--trace",
-        "true" if repository_ctx.GetTrace() else "false"
+        "true" if repository_ctx.GetTrace() else "false",
+        "--handler",
+        repository_ctx.extraction_handler,
     ]
 
     _exec(repository_ctx, fetch_cmd, repository_ctx.GetPodRootDir())
@@ -280,13 +284,14 @@ def new_pod_repository(name,
             podspec_url = None,
             strip_prefix = "",
             user_options = [],
-            install_script = None, 
+            install_script = None,
             inhibit_warnings = False,
             trace = False,
             enable_modules = True,
             generate_module_map = True,
             owner = "", # This is a Noop
-            header_visibility = "pod_support"):
+            header_visibility = "pod_support"
+            extraction_handler = "default"):
     """Declare a repository for a Pod
     Args:
          name: the name of this repo
@@ -347,6 +352,10 @@ def new_pod_repository(name,
 
          header_visibility: DEPRECATED: This is replaced by headermaps:
          https://github.com/bazelbuild/bazel/pull/3712
+
+         extraction_handler: override for what archive type to treat the file as
+         when extracting it, supports `tar` and `zip`.  The default is `default`
+         which will try and infer from the file extension of the target file.
     """
 
     # The SRC_ROOT is the directory of the WORKSPACE and Pods.WORKSPACE
@@ -367,7 +376,8 @@ def new_pod_repository(name,
             enable_modules = enable_modules,
             generate_module_map = generate_module_map,
             header_visibility = header_visibility,
-            src_root = SRC_ROOT)
+            src_root = SRC_ROOT,
+            extraction_handler = extraction_handler)
     _update_repo_impl(repository_ctx)
 
 def _cleanupPods():

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -290,7 +290,7 @@ def new_pod_repository(name,
             enable_modules = True,
             generate_module_map = True,
             owner = "", # This is a Noop
-            header_visibility = "pod_support"
+            header_visibility = "pod_support",
             extraction_handler = "default"):
     """Declare a repository for a Pod
     Args:

--- a/bin/update_pods.py
+++ b/bin/update_pods.py
@@ -167,7 +167,7 @@ def _load_repo_if_needed(repository_ctx, repo_tool_bin_path):
     if not url:
         # We allow putting source code in the Vendor/PodName and then initing
         # the repo with that code.
-	return
+        return
 
     # Note: the pod is not cleaned out if the sourcecode is loaded from the
     # current directory

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.22.0"
-BAZEL_VERSION_SHA="adae5bbc3bf2b9b60d460d8ea2c65da1a6edd75b242439dfc49d001272548d13"
+BAZEL_VERSION="0.25.2"
+BAZEL_VERSION_SHA="10ff77f7cdf29385d80770b1608dc39aa247610ee6cae627684a979e086cca13"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"


### PR DESCRIPTION
This allows for better detection support and adds an optional parameter to the repository definition to allow for explicitly overriding the extraction handler.  This is to allow for both `.tgz` files implicitly as well as allow for overriding the detection logic when the full URL doesn't provide an extension by default (like URLs from `codeload.github.com` which end with the commit SHA).